### PR TITLE
Joystick Relocation on Click Position.

### DIFF
--- a/addons/virtual_joystick/scripts/virtual_joystick.gd
+++ b/addons/virtual_joystick/scripts/virtual_joystick.gd
@@ -6,6 +6,7 @@ signal analogic_released
 
 export(Texture) var border = null setget set_border
 export(Texture) var stick = null setget set_stick
+export var relocate_position_on_click := false # if it is true, It is hidden when the joystick is released, and when the screen is clicked, it appears by centering that point.
 
 var joystick = Sprite.new()
 var touch = TouchScreenButton.new()
@@ -44,6 +45,8 @@ func _enter_tree() -> void:
 
 
 func _ready() -> void:
+	if relocate_position_on_click == true:
+		hide()
 	touch.connect("released", self, "_on_released")
 	update()
 


### PR DESCRIPTION
Most of my testers requested "When I press anywhere on screen, I want to relocate the joysticks position." I made it usable with one boolean export parameter.